### PR TITLE
fix(publish-docs): parse markdown code blocks into custom x-code element

### DIFF
--- a/packages/publish-docs/package.json
+++ b/packages/publish-docs/package.json
@@ -52,6 +52,7 @@
     "@lexical/table": "^0.33.0",
     "chalk": "^5.4.1",
     "gray-matter": "^4.0.3",
+    "he": "^1.2.0",
     "image-size": "^2.0.2",
     "jsdom": "^26.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -66,6 +67,7 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
+    "@types/he": "^1.2.3",
     "@types/jsdom": "^21.1.7",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^18.0.0",

--- a/packages/publish-docs/src/converter/index.ts
+++ b/packages/publish-docs/src/converter/index.ts
@@ -90,7 +90,7 @@ export class Converter {
 
         if (lang === "mermaid") return `<pre class="mermaid">${text}</pre>`;
 
-        // 将 title/icon/其他属性都转成 data-* 属性
+        // Convert title/icon and other attributes to data-* attributes
         const dataAttrs = Object.entries(attrs)
           .map(([k, v]) => `data-${he.encode(k)}="${he.encode(v)}"`)
           .join(" ");

--- a/packages/publish-docs/src/converter/nodes/custom-component-node.ts
+++ b/packages/publish-docs/src/converter/nodes/custom-component-node.ts
@@ -102,6 +102,7 @@ export class CustomComponentNode extends DecoratorBlockNode {
 
   static override importDOM(): DOMConversionMap | null {
     return {
+      "x-code": () => ({ conversion: convertCustomComponentElement, priority: 1 }),
       "x-card": () => ({ conversion: convertCustomComponentElement, priority: 1 }),
       "x-cards": () => ({ conversion: convertCustomComponentElement, priority: 1 }),
       "x-code-group": () => ({ conversion: convertCustomComponentElement, priority: 1 }),

--- a/packages/publish-docs/src/utils/parse-code-lang-str.ts
+++ b/packages/publish-docs/src/utils/parse-code-lang-str.ts
@@ -1,7 +1,7 @@
 export type LangAttrs = {
   icon?: string;
-  foldable?: string; // 是否启用折叠功能
-  foldThreshold?: string; // 折叠阈值，超过此行数自动折叠
+  foldable?: string; // Whether to enable folding functionality
+  foldThreshold?: string; // Folding threshold - auto-fold when line count exceeds this value
 };
 
 /**
@@ -32,7 +32,7 @@ export function parseCodeLangStr(lang: string = "") {
     rest.forEach((part) => {
       const match = part.match(keyValueRegex);
       if (match) {
-        // biome-ignore lint/style/noNonNullAssertion: 需要使用非空断言以保证类型安全
+        // biome-ignore lint/style/noNonNullAssertion: Non-null assertion needed for type safety
         attrs[match[1]! as keyof LangAttrs] = match[2]!;
       } else {
         titleParts.push(part);

--- a/packages/publish-docs/src/utils/parse-code-lang-str.ts
+++ b/packages/publish-docs/src/utils/parse-code-lang-str.ts
@@ -1,0 +1,46 @@
+export type LangAttrs = {
+  icon?: string;
+  foldable?: string; // 是否启用折叠功能
+  foldThreshold?: string; // 折叠阈值，超过此行数自动折叠
+};
+
+/**
+ * 支持解析 markdown 中带参数的 code block, 例如:
+ *
+ * ```js MyTitle icon='mdi:javascript'
+ * console.log('Hello, world!')
+ * ```
+ *
+ * 解析后返回
+ * {
+ *   lang: 'js',
+ *   title: 'MyTitle',
+ *   icon: 'material-symbols:javascript'
+ * }
+ */
+export function parseCodeLangStr(lang: string = "") {
+  const parts = lang.trim().split(/\s+/);
+  const actualLang = parts[0] || "";
+  let title = "";
+  const attrs: LangAttrs = {};
+
+  if (parts.length > 1) {
+    const rest = parts.slice(1);
+    const keyValueRegex = /^(\w+)=(.+)$/;
+
+    const titleParts: string[] = [];
+    rest.forEach((part) => {
+      const match = part.match(keyValueRegex);
+      if (match) {
+        // biome-ignore lint/style/noNonNullAssertion: 需要使用非空断言以保证类型安全
+        attrs[match[1]! as keyof LangAttrs] = match[2]!;
+      } else {
+        titleParts.push(part);
+      }
+    });
+
+    title = titleParts.join(" ");
+  }
+
+  return { lang: actualLang, title, ...attrs };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      he:
+        specifier: ^1.2.0
+        version: 1.2.0
       image-size:
         specifier: ^2.0.2
         version: 2.0.2
@@ -84,6 +87,9 @@ importers:
         specifier: ^3.25.67
         version: 3.25.76
     devDependencies:
+      '@types/he':
+        specifier: ^1.2.3
+        version: 1.2.3
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
@@ -302,6 +308,9 @@ packages:
     resolution: {integrity: sha512-Zx1rabMm/Zjk7n7YQMIQLUN+tqzcg1xqcgNpEHSfK1GA8QMPXCPvXWFT3ZDC4tfZOSy/YIqpVUyWZAomFqRa+g==}
     peerDependencies:
       yjs: '>=13.5.22'
+
+  '@types/he@1.2.3':
+    resolution: {integrity: sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==}
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
@@ -632,6 +641,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -1600,6 +1613,8 @@ snapshots:
       lexical: 0.33.1
       yjs: 13.6.27
 
+  '@types/he@1.2.3': {}
+
   '@types/jsdom@21.1.7':
     dependencies:
       '@types/node': 24.3.0
@@ -2003,6 +2018,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  he@1.2.0: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

- relates https://team.arcblock.io/comment/discussions/6e0c16ed-4bdb-4dc5-8f52-9ee556fe0b0a


### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

1. ajusted: parse markdown code blocks into custom x-code element

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

<img width="937" height="318" alt="image" src="https://github.com/user-attachments/assets/9c749ddc-77dd-4f2c-beab-7200690475e2" />

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**New Feature**: Enhanced Code Block Handling
- Added support for parsing and rendering code blocks with advanced language attributes
- Improved code block display with custom x-code element implementation
- Enhanced language string parsing for better syntax highlighting

These changes improve how code examples are displayed in documentation, providing better syntax highlighting and more flexible code block formatting options for content authors.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->