### PR TITLE
fix: polish image update logic

### DIFF
--- a/packages/publish-docs/src/converter/index.ts
+++ b/packages/publish-docs/src/converter/index.ts
@@ -235,17 +235,18 @@ export class Converter {
 
     content.root.children.forEach(collectImageSources);
 
-    if (localImageSources.length === 0) return;
+    let localImageFiles: string[] = [];
+    let foundImagePaths: Map<string, string> = new Map();
 
-    // Find local image files
-    const imageSearchResult = findLocalImages(localImageSources, {
-      mediaFolder: this.uploadConfig.mediaFolder,
-      markdownFilePath: filePath,
-    });
-    const foundImagePaths = imageSearchResult.foundPaths;
-    const localImageFiles = Array.from(foundImagePaths.values());
-
-    if (localImageFiles.length === 0) return;
+    if (localImageSources.length > 0) {
+      // Find local image files
+      const imageSearchResult = findLocalImages(localImageSources, {
+        mediaFolder: this.uploadConfig.mediaFolder,
+        markdownFilePath: filePath,
+      });
+      foundImagePaths = imageSearchResult.foundPaths;
+      localImageFiles = Array.from(foundImagePaths.values());
+    }
 
     try {
       // Upload images


### PR DESCRIPTION
## Related Issue

https://team.arcblock.io/task/task/620027947058724864

### Major Changes

1. 修复图片更新的逻辑，解决只有本地图片时不走图片信息更新逻辑的问题

### Screenshots
<img width="781" height="528" alt="image" src="https://github.com/user-attachments/assets/dc06c2a6-2840-4f55-a3ee-4108d1985465" />


### Test Plan

- [x] 文档中只有远程图片，仍能正常更新

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- Refactor: Improved image processing logic to handle cases where local images are not present more gracefully. This change ensures the documentation build process continues smoothly regardless of whether local images are used.

The update streamlines the image handling workflow without changing end-user functionality or documentation output.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->